### PR TITLE
add only_replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ spell = Speller(fast=True)
 ```
 Now, the correction should always work in microseconds, but words with double typos (like 'consiousnes') won't be corrected.
 
+# OCR
+When cleaning up OCR, replacements are the large majority of errors. If this is the case, you may want to use the option 'only_replacements':
+```python
+spell = Speller(only_replacements=True)
+```
+
 # Adding new languages
 First add special letters in autocorrect/constants.py.
 

--- a/autocorrect/__init__.py
+++ b/autocorrect/__init__.py
@@ -70,11 +70,14 @@ def load_from_tar(lang, file_name="word_count.json"):
 
 
 class Speller:
-    def __init__(self, lang="en", threshold=0, nlp_data=None, fast=False):
+    def __init__(
+        self, lang="en", threshold=0, nlp_data=None, fast=False, only_replacements=False
+    ):
         self.lang = lang
         self.threshold = threshold
         self.nlp_data = load_from_tar(lang) if nlp_data is None else nlp_data
         self.fast = fast
+        self.only_replacements = only_replacements
 
         if threshold > 0:
             # print(f'Original number of words: {len(self.nlp_data)}')
@@ -86,7 +89,7 @@ class Speller:
         return {word for word in words if word in self.nlp_data}
 
     def get_candidates(self, word):
-        w = Word(word, self.lang)
+        w = Word(word, self.lang, self.only_replacements)
         if self.fast:
             candidates = self.existing([word]) or self.existing(w.typos()) or [word]
         else:

--- a/autocorrect/typos.py
+++ b/autocorrect/typos.py
@@ -22,9 +22,9 @@ from autocorrect.constants import alphabets
 class Word:
     """container for word-based methods"""
 
-    __slots__ = ["slices", "word", "alphabet"]  # optimization
+    __slots__ = ["slices", "word", "alphabet", "only_replacements"]  # optimization
 
-    def __init__(self, word, lang="en"):
+    def __init__(self, word, lang="en", only_replacements=False):
         """
         Generate slices to assist with typo
         definitions.
@@ -37,6 +37,7 @@ class Word:
         self.slices = tuple((word[:i], word[i:]) for i in slice_range)
         self.word = word
         self.alphabet = alphabets[lang]
+        self.only_replacements = only_replacements
 
     def _deletes(self):
         """th"""
@@ -62,10 +63,16 @@ class Word:
 
     def typos(self):
         """letter combinations one typo away from word"""
-        return chain(
-            self._deletes(), self._transposes(), self._replaces(), self._inserts()
-        )
+        if self.only_replacements:
+            return chain(self._replaces())
+        else:
+            return chain(
+                self._deletes(), self._transposes(), self._replaces(), self._inserts()
+            )
 
     def double_typos(self):
         """letter combinations two typos away from word"""
-        return chain.from_iterable(Word(e1).typos() for e1 in self.typos())
+        return chain.from_iterable(
+            Word(e1, only_replacements=self.only_replacements).typos()
+            for e1 in self.typos()
+        )

--- a/test_all.py
+++ b/test_all.py
@@ -87,6 +87,15 @@ upper = {
     "I": "I",
 }
 
+only_replacements = {
+    "other": "ather",
+    "health": "heaith",
+    "should": "shauld",
+    "mental": "mentat",
+    "also": "aiso",
+    "order": "arder",
+}
+
 spanish_words_all_correct = {
     "hola": "hola",
     "hambre": "hanbre",
@@ -940,6 +949,11 @@ def test_sentences():
 
 def test_uppercase():
     assert spelltest(spell, upper) == 0
+
+
+def test_replacements():
+    spell_replace = Speller(only_replacements=True)
+    assert spelltest(spell_replace, only_replacements) == 0
 
 
 def test_empty():

--- a/test_all.py
+++ b/test_all.py
@@ -94,6 +94,8 @@ only_replacements = {
     "mental": "mentat",
     "also": "aiso",
     "order": "arder",
+    "they": "thew",  # they, not the
+    "here": "herw",  # here, not her
 }
 
 spanish_words_all_correct = {


### PR DESCRIPTION
Add option to only perform replacements. Useful for cleaning OCR output, as most mistakes are replacements.